### PR TITLE
setting width of page to device's width

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>SAST</title>
   <link rel="stylesheet" href="./src/index.css">
+  <meta name = "viewport"
+  content = "width=device-width,
+  initial-scale=1.0"/>
 </head>
 
 <body>


### PR DESCRIPTION
this tells the browser to set the width of the page to the device's width and not to zoom in initially. Without this, mobile browsers might render the page as if it's on a desktop, then shrink it, making text tiny. 